### PR TITLE
Add Go to first XRef keybind

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Some of the available data types are visible on the screenshot below:
 Other than the obvious (arrows, home/end, page up/down), you can press:
 
 * `ENTER` - accept the current selection (go to the selected location, or execute the selected script, etc).
+* `Ctrl+Enter` - Go to the first XRef of the selected location if one exists.
 * `ESC` - close the current window without doing anything
 * `Ctrl+c` - copy a text of the highlighted element
 * `Ctrl+Shift+c` - copy address (if any) of the highlighted element

--- a/ctrlp.py
+++ b/ctrlp.py
@@ -346,7 +346,7 @@ class SymbolFilterWindow(JFrame):
             clipboard = Toolkit.getDefaultToolkit().getSystemClipboard()
             string_selection = StringSelection("0x" + str(selected_symbol.address))
             clipboard.setContents(string_selection, None)
-    
+
     def goToFirstXRef(self):
         success = False
         selected_symbol = self.current_symbol()

--- a/ctrlp.py
+++ b/ctrlp.py
@@ -346,6 +346,16 @@ class SymbolFilterWindow(JFrame):
             clipboard = Toolkit.getDefaultToolkit().getSystemClipboard()
             string_selection = StringSelection("0x" + str(selected_symbol.address))
             clipboard.setContents(string_selection, None)
+    
+    def goToFirstXRef(self):
+        success = False
+        selected_symbol = self.current_symbol()
+        if selected_symbol and selected_symbol.address:
+            ref_manager = currentProgram.getReferenceManager()
+            if ref_manager.getReferenceCountTo(selected_symbol.address) > 0:
+                goTo(ref_manager.getReferencesTo(selected_symbol.address).next().getFromAddress())
+                success = True
+        return success
 
     def cancelNavigation(self):
         goTo(self.initial_address)
@@ -379,7 +389,10 @@ class FilterKeyAdapter(KeyAdapter):
         self.parent.navigateToSelectedSymbol()
 
     def keyPressed(self, event):
-        if event.getKeyCode() == KeyEvent.VK_ENTER:
+        if event.isControlDown() and event.getKeyCode() == KeyEvent.VK_ENTER:
+            if self.parent.goToFirstXRef():
+                self.parent.setVisible(False)
+        elif event.getKeyCode() == KeyEvent.VK_ENTER:
             self.parent.setVisible(False)
             self.parent.runSelectedAction()
         elif event.getKeyCode() == KeyEvent.VK_UP:


### PR DESCRIPTION
Thanks for the tool - used it extensively yesterday and has completely change the way I navigate in Ghidra - Genuine QoL improvement.

The PR adds support for an "I'm feeling lucky" style XRef follow keybind.

When selecting an entry with a symbol that has at least 1 XRef pressing `Ctrl-Enter` will navigate to the first XRef rather than the symbol address itself.

Particularly useful to navigate directly to a function that uses a string. If no XRefs are present the Ctrl-P window remains open to highlight there is nothing to go to and thus the user can just hit Enter to go to the Symbol address.