### PR TITLE
Reduce the number of logs

### DIFF
--- a/CtrlPQuicklaunchScript.java
+++ b/CtrlPQuicklaunchScript.java
@@ -12,16 +12,13 @@ public class CtrlPQuicklaunchScript extends GhidraScript {
     @Override
     public void run() throws Exception {
         String expectedName = "CtrlP - " + getCurrentProgram().getDomainFile().toString();
-        println("Looking for " + expectedName);
         for (Window window : Window.getWindows()) {
             if (window instanceof JFrame) {
                 JFrame frame = (JFrame) window;
                 if (frame.getTitle().equals(expectedName) && frame.isDisplayable()) {
                     if (frame.isShowing()) {
-                        println("Found, hiding");
                         frame.setVisible(false);
                     } else {
-                        println("Found, showing");
                         frame.setVisible(true);
                     }
                     return;
@@ -29,11 +26,11 @@ public class CtrlPQuicklaunchScript extends GhidraScript {
             }
         }
 
-        println("Not found, launching it");
+        println("CtrlP window not found, launching it: " + expectedName);
         ConsoleService consoleService = state.getTool().getService(ConsoleService.class);
         ResourceFile script = GhidraScriptUtil.findScriptByName("ctrlp.py");
         if (script == null) {
-            println("ctrl.py script not found - install it, or run it manually if you changed the name");
+            println("ctrl.py script not found - install it, or run it manually if you changed the filename");
             return;
         }
 

--- a/ctrlp.py
+++ b/ctrlp.py
@@ -649,7 +649,6 @@ def run_or_restore():
                 else:
                     print("Window is alredy visible. Doing nothing")
                 return
-    print("No window, spawning it")
     run()
 
 


### PR DESCRIPTION
The logs are basically debug logs, and now the plugin is more stable, there's no point spamming Ghidra script output window.