### PR TITLE
Limit the search to 1000 entries

### DIFF
--- a/ctrlp.py
+++ b/ctrlp.py
@@ -284,6 +284,14 @@ class SymbolFilterWindow(JFrame):
             filtered_symbols = [
                 sym for sym in self.symbols if matches(sym.text, filter_text)
             ]
+            if len(filtered_symbols) > 1000:
+                overflow = len(filtered_symbols) - 1000
+                filtered_symbols = filtered_symbols[:1000]
+                filtered_symbols.append(SearchEntry(
+                    "txt and " + str(overflow) + " more...",
+                    None,
+                    lambda: None
+                ))
             filtered_symbols = sorted(filtered_symbols, key=get_order)
 
         self.filtered_symbols = filtered_symbols


### PR DESCRIPTION
Some users reported that the window is laggy (and I recently also noticed it on a binary with over 50k symbols). This PR should improve the situation somewhat.

A limit of 1000 displayed entries looks large enough that nobody will actually scroll through it, while being reasonably fast.